### PR TITLE
Allow HTML in Markdown

### DIFF
--- a/brut/package.json
+++ b/brut/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brut",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "private": false,
   "license": "MIT",
   "repository": {

--- a/brut/src/buildPages.ts
+++ b/brut/src/buildPages.ts
@@ -58,12 +58,12 @@ function processMarkdown(file: string): Promise<string> {
        * `remark-rehype` transforms the mdast into hast.
        * https://github.com/remarkjs/remark-rehype
        */
-      .use(remarkRehype)
+      .use(remarkRehype, { allowDangerousHtml: true })
       /**
        * `rehype-stringify` transforms the hast into HTML.
        * https://github.com/rehypejs/rehype/tree/main/packages/rehype-stringify
        */
-      .use(rehypeStringify)
+      .use(rehypeStringify, { allowDangerousHtml: true })
       .process(file)
       .then((vfile) => String(vfile))
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ]
     },
     "brut": {
-      "version": "0.0.24",
+      "version": "0.0.25",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^10.0.0",

--- a/www/pages/posts/second-post.md
+++ b/www/pages/posts/second-post.md
@@ -1,0 +1,23 @@
+---
+template: /templates/default.html
+title: "Second Post"
+date: "2022-02-12"
+---
+
+# Second Post
+
+This post is written in Markdown but contains embedded HTML:
+
+<ul>
+<li>This</li>
+<li>Is</li>
+<li>An</li>
+<li>HTML</li>
+<li>List</li>
+</ul>
+
+- This
+- Is
+- A
+- Markdown
+- List


### PR DESCRIPTION
This is necessary to e.g. add embeds (typically iframes) to Markdown posts.

Passing `allowDangerousHtml` to unified plugins solves it.