### PR TITLE
Inject HTML into a template before running the build script

### DIFF
--- a/brut/package.json
+++ b/brut/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brut",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "private": false,
   "license": "MIT",
   "repository": {

--- a/brut/src/buildPages.ts
+++ b/brut/src/buildPages.ts
@@ -91,13 +91,7 @@ async function buildPage(
   content: string,
   frontmatter: Frontmatter
 ): Promise<string> {
-  // 1. run build script
-  const hasScript = !!frontmatter.buildScript;
-  if (hasScript) {
-    const script = await import(cwd() + frontmatter.buildScript);
-    content = await script.buildPage(content);
-  }
-  // 2. inject into the template
+  // 1. inject into the template
   const hasTemplate = !!frontmatter.template;
   if (hasTemplate) {
     const template = await readFile(cwd() + frontmatter.template, "utf-8");
@@ -106,6 +100,12 @@ async function buildPage(
       frontmatter, // variables
       { content } // partials
     );
+  }
+  // 2. run build script
+  const hasScript = !!frontmatter.buildScript;
+  if (hasScript) {
+    const script = await import(cwd() + frontmatter.buildScript);
+    content = await script.buildPage(content);
   }
   // 3. minify and return
   return minify(content);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ]
     },
     "brut": {
-      "version": "0.0.25",
+      "version": "0.0.26",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^10.0.0",


### PR DESCRIPTION
Changing the order of processing expose the templates themselves to build scripts. Example use case: the website's navigation (part of a template) needs to be generated at build time to include all pages.