### PR TITLE
Fix 404

### DIFF
--- a/brut/package.json
+++ b/brut/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brut",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "private": false,
   "license": "MIT",
   "repository": {

--- a/brut/src/buildPages.js
+++ b/brut/src/buildPages.js
@@ -165,8 +165,13 @@ export default async function buildPages({ outDir: outDirRoot, pagesDir }) {
           // 4. build page and write to fs
           const relPath = outDir.replace(outDirRoot, "");
           const result = await buildPage(html, frontmatter, relPath);
-          await ensureDir(outDir);
-          await writeFile(`${outDir}/index.html`, result);
+          // TEMP: handle 404 pages for Cloudflare Pages
+          if (outDir === `${outDirRoot}/404`) {
+            await writeFile(`${outDir}.html`, result);
+          } else {
+            await ensureDir(outDir);
+            await writeFile(`${outDir}/index.html`, result);
+          }
         }
       })
     );

--- a/www/pages/404.md
+++ b/www/pages/404.md
@@ -1,0 +1,5 @@
+---
+template: /templates/default.html
+---
+
+## Not found


### PR DESCRIPTION
Closes #20 

This is a temporary fix that ensures that any `404.html` or `404.md` page is built into `/404.html` and not `/404/index.html`, to work with Cloudflare Pages as a static site host.

Eventually this should be done via something like a frontmatter `permalink` key, new issue coming up (see the thread on #20).
