### PR TITLE
Expose mustache partials

### DIFF
--- a/brut/package.json
+++ b/brut/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brut",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "private": false,
   "license": "MIT",
   "repository": {

--- a/brut/src/buildPages.js
+++ b/brut/src/buildPages.js
@@ -161,6 +161,7 @@ async function buildPage(
 }
 
 /**
+ * Recursively list files in a directory
  * @param {string} dir
  * @returns {Promise<string[]>}
  */

--- a/brut/src/index.js
+++ b/brut/src/index.js
@@ -8,6 +8,8 @@ const { emptyDir } = fs;
 /**
  * @typedef {Object} ConfigObject
  * @property {string} [pagesDir] The top-level directory containing pages. Defaults to `/pages`.
+ * @property {string} [templatesDir] The top-level directory containing templates. Defaults to `/templates`.
+ * @property {string} [partialsDir] The top-level directory containing partials. Defaults to `/partials`.
  * @property {string} [publicDir] The top-level directory containing static assets to copy to the `outDir`. Defaults to `/public`.
  * @property {string} [outDir] The top-level directory for the build output. Defaults to `/dist`.
  */
@@ -22,6 +24,12 @@ async function getConfig() {
     pagesDir: configObject.pagesDir
       ? `${cwd()}${configObject.pagesDir}`
       : `${cwd()}/pages`,
+    templatesDir: configObject.templatesDir
+      ? `${cwd()}${configObject.templatesDir}`
+      : `${cwd()}/templates`,
+    partialsDir: configObject.partialsDir
+      ? `${cwd()}${configObject.partialsDir}`
+      : `${cwd()}/partials`,
     publicDir: configObject.publicDir
       ? `${cwd()}${configObject.publicDir}`
       : `${cwd()}/public`,

--- a/www/pages/404.md
+++ b/www/pages/404.md
@@ -1,5 +1,5 @@
 ---
-template: /templates/default.html
+template: default.html
 ---
 
 ## Not found

--- a/www/pages/404.md
+++ b/www/pages/404.md
@@ -1,5 +1,5 @@
 ---
-template: default.html
+template: default
 ---
 
 ## Not found

--- a/www/pages/index.html
+++ b/www/pages/index.html
@@ -1,5 +1,5 @@
 <!--
-template: default.html
+template: default
 -->
 
 <h1>Welcome to Brut</h1>

--- a/www/pages/index.html
+++ b/www/pages/index.html
@@ -1,5 +1,5 @@
 <!--
-template: /templates/default.html
+template: default.html
 -->
 
 <h1>Welcome to Brut</h1>

--- a/www/pages/posts.md
+++ b/www/pages/posts.md
@@ -1,5 +1,5 @@
 ---
-template: /templates/default.html
+template: default.html
 buildScript: /scripts/buildPostsPage.js
 ---
 

--- a/www/pages/posts.md
+++ b/www/pages/posts.md
@@ -1,5 +1,5 @@
 ---
-template: default.html
+template: default
 buildScript: /scripts/buildPostsPage.js
 ---
 

--- a/www/pages/posts/second-post.md
+++ b/www/pages/posts/second-post.md
@@ -1,5 +1,5 @@
 ---
-template: default.html
+template: default
 title: "Second Post"
 date: "2022-02-12"
 ---

--- a/www/pages/posts/second-post.md
+++ b/www/pages/posts/second-post.md
@@ -1,5 +1,5 @@
 ---
-template: /templates/default.html
+template: default.html
 title: "Second Post"
 date: "2022-02-12"
 ---

--- a/www/pages/posts/unpopular-opinion.md
+++ b/www/pages/posts/unpopular-opinion.md
@@ -1,5 +1,5 @@
 ---
-template: default.html
+template: default
 title: "Unpopular Opinion"
 date: "2021-11-12"
 ---

--- a/www/pages/posts/unpopular-opinion.md
+++ b/www/pages/posts/unpopular-opinion.md
@@ -1,5 +1,5 @@
 ---
-template: /templates/default.html
+template: default.html
 title: "Unpopular Opinion"
 date: "2021-11-12"
 ---

--- a/www/partials/nav.html
+++ b/www/partials/nav.html
@@ -1,0 +1,8 @@
+<header>
+  <nav>
+    <ul>
+      <li><a href="/">Home</a></li>
+      <li><a href="/posts">Blog</a></li>
+    </ul>
+  </nav>
+</header>

--- a/www/templates/default.html
+++ b/www/templates/default.html
@@ -11,12 +11,7 @@
     />
   </head>
   <body>
-    <nav>
-      <ul>
-        <li><a href="/">Home</a></li>
-        <li><a href="/posts">Blog</a></li>
-      </ul>
-    </nav>
+    {{> nav}}
     <main>{{> content}}</main>
   </body>
 </html>


### PR DESCRIPTION
Closes #28, #32 

This exposes mustache partials to users. Any file saved under a new partials directory (defaults to `/partials`, configurable) will be loaded and passed to the mustache engine at build time. Partials can be referenced in pages by their slugs, e.g. `/partials/nav.html` :point_right: `{{ > nav }}`.

It also comes with a breaking change for templates. Instead of saving template files anywhere and referencing them by their path (e.g. `template: /templates/default.html`), templates now must be saved to a new templates directory (defaults to `/templates`, configurable). They can be referenced in frontmatter by their slugs, e.g. `/templates/default.html` :point_right: `template: default`. Besides aligning the templates and partials APIs, one major benefit of this is that brut can load all templates once at the beginning of the build, instead of having to load them on the fly as their path is read from frontmatter. I expect significant build time improvements.